### PR TITLE
-Add new line to "META-INF/services/org.yamcs.Plugin" in the right place.

### DIFF
--- a/src/main/java/org/yamcs/maven/DetectMojo.java
+++ b/src/main/java/org/yamcs/maven/DetectMojo.java
@@ -97,8 +97,8 @@ public class DetectMojo extends AbstractMojo {
         try (FileWriter writer = new FileWriter(spiFile)) {
             for (JavaClass yamcsPluginClass : yamcsPluginClasses) {
                 writer.write(yamcsPluginClass.getFullyQualifiedName());
+		writer.write("\n");
             }
-            writer.write("\n");
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to write " + spiFile, e);
         }


### PR DESCRIPTION
Hi everyone,

Hope you are all doing well.

Was trying to load more than one plugin and YAMCS errored out. Hopefully this fix explains why.
As per [documentation](https://docs.yamcs.org/yamcs-server-manual/yamcs-plugin-format/)
```
The content of this file must list the class names of all the plugins in your jar (one on each line). So for instance if you want to register your plugin com.example.MyPlugin, then the contents of the file org.yamcs.Plugin must be simply:
```


The new line write was outside of the loop.

Cheers
Lorenzo